### PR TITLE
Completed Shelley's list

### DIFF
--- a/KPSmart/src/controller/FormController.java
+++ b/KPSmart/src/controller/FormController.java
@@ -673,7 +673,7 @@ public class FormController implements Initializable {
 				Parent popupGUI = popup.load();
 				modal = new Stage();
 				modal.setScene(new Scene(popupGUI));
-				modal.setTitle("My modal window");
+				modal.setTitle("Enter customer price");
 				modal.initModality(Modality.APPLICATION_MODAL);
 				modal.initOwner(submit.getScene().getWindow());
 				modal.showAndWait();

--- a/KPSmart/src/controller/PopUpController.java
+++ b/KPSmart/src/controller/PopUpController.java
@@ -39,6 +39,8 @@ public class PopUpController implements Initializable {
 	private TextField weightPrice;
 	@FXML
 	private TextField volumePrice;
+	@FXML
+	private Text error;
 	
 	@FXML
 	private void popUpSubmit(){
@@ -54,6 +56,9 @@ public class PopUpController implements Initializable {
 			r.setPrice(price);
 			System.out.println(r.getPrice().toString());
 			c.closeModal();
+		}
+		else{
+			error.visibleProperty().bind(hasError);
 		}
 	}
 	

--- a/KPSmart/src/controller/ReportsController.java
+++ b/KPSmart/src/controller/ReportsController.java
@@ -2,6 +2,7 @@ package controller;
 
 import java.io.IOException;
 import java.net.URL;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.ResourceBundle;
@@ -28,6 +29,9 @@ import main.Tuple;
 public class ReportsController implements Initializable {
 	
 	private Main main;
+	
+	private DecimalFormat df = new DecimalFormat("0.00");
+	private DecimalFormat sf = new DecimalFormat("0");
 
 	public ReportsController(Main main){
 		this.main = main;
@@ -37,9 +41,9 @@ public class ReportsController implements Initializable {
 	public void initialize(URL arg0, ResourceBundle arg1) {}
 	 
 	public void initData(){
-		expenditure.setText(Double.toString(main.getTotalExp()));
-		revenue.setText(Double.toString(main.getTotalRev()));
-		eventcount.setText(Double.toString(main.getTotalEvents()));
+		expenditure.setText("$" +  df.format(main.getTotalExp()));
+		revenue.setText("$" +  df.format(main.getTotalRev()));
+		eventcount.setText(sf.format(main.getTotalEvents()));
 		routeLoadAction();
 	}
 	
@@ -239,7 +243,7 @@ public class ReportsController implements Initializable {
 	    HashMap<Tuple, ArrayList<Double>> temp = main.getAmountOfMail();
 	    report = new ArrayList<RouteLoadRow>();
 	    for(Tuple t: temp.keySet()){
-	    	RouteLoadRow row = new RouteLoadRow(t.getOrigin(), t.getDestination(), Double.toString(temp.get(t).get(0)), Double.toString(temp.get(t).get(1)), Double.toString(temp.get(t).get(2)));
+	    	RouteLoadRow row = new RouteLoadRow(t.getOrigin(), t.getDestination(), Double.toString(temp.get(t).get(0)), Double.toString(temp.get(t).get(1)), sf.format(temp.get(t).get(2)));
 	    	report.add(row);
 	    }
 	   

--- a/KPSmart/src/views/deliveryrequest.fxml
+++ b/KPSmart/src/views/deliveryrequest.fxml
@@ -29,7 +29,7 @@
                   <Font name="Gulim" size="13.0" />
                </font>
             </Button>
-            <MenuButton fx:id="logeventmenu" layoutX="-1.0" layoutY="1.0" mnemonicParsing="false" prefHeight="24.0" prefWidth="184.0" style="-fx-background-color: E9D5B9;" text="Log Event">
+            <MenuButton fx:id="logeventmenu" layoutX="-1.0" layoutY="1.0" mnemonicParsing="false" prefHeight="24.0" prefWidth="184.0" style="-fx-background-color: E9D5B9;" text="Delivery Request">
               <items>
                 <MenuItem fx:id="transportRoute" mnemonicParsing="false" onAction="#transportRouteAction" text="Transport Route" />
                 <MenuItem fx:id="deliveryRequest" mnemonicParsing="false" onAction="#deliveryRequestAction" text="Delivery Request" />

--- a/KPSmart/src/views/discontinuetransport.fxml
+++ b/KPSmart/src/views/discontinuetransport.fxml
@@ -29,7 +29,7 @@
                   <Font name="Gulim" size="13.0" />
                </font>
             </Button>
-            <MenuButton fx:id="logeventmenu" layoutX="-1.0" layoutY="1.0" mnemonicParsing="false" prefHeight="24.0" prefWidth="184.0" style="-fx-background-color: E9D5B9;" text="Log Event">
+            <MenuButton fx:id="logeventmenu" layoutX="-1.0" layoutY="1.0" mnemonicParsing="false" prefHeight="24.0" prefWidth="184.0" style="-fx-background-color: E9D5B9;" text="Discontinue Transport">
               <items>
                 <MenuItem fx:id="transportRoute" mnemonicParsing="false" onAction="#transportRouteAction" text="Transport Route" />
                 <MenuItem fx:id="deliveryRequest" mnemonicParsing="false" onAction="#deliveryRequestAction" text="Delivery Request" />

--- a/KPSmart/src/views/popup.fxml
+++ b/KPSmart/src/views/popup.fxml
@@ -12,12 +12,12 @@
 
 <AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="235.0" prefWidth="385.0" style="-fx-background-color: FFF3E0;" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <Text layoutX="28.0" layoutY="45.0" strokeType="OUTSIDE" strokeWidth="0.0" text="There is no related Customer Price in the system. Please enter one." wrappingWidth="327.1347961425781">
+      <Text layoutX="28.0" layoutY="59.0" strokeType="OUTSIDE" strokeWidth="0.0" text="There is no related Customer Price in the system. Please enter one." wrappingWidth="327.1347961425781">
          <font>
             <Font name="Gulim" size="14.0" />
          </font>
       </Text>
-      <GridPane hgap="5.0" layoutX="30.0" layoutY="89.0" prefHeight="64.0" prefWidth="312.0" vgap="5.0">
+      <GridPane hgap="5.0" layoutX="30.0" layoutY="98.0" prefHeight="64.0" prefWidth="312.0" vgap="5.0">
          <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
@@ -46,11 +46,16 @@
             <Font name="Gulim" size="15.0" />
          </font>
       </Button>
-      <Button id="submit" layoutX="160.0" layoutY="176.0" mnemonicParsing="false" onAction="#popUpSubmit" style="-fx-background-color: E9D5B9;" text="Submit">
+      <Button id="submit" layoutX="160.0" layoutY="186.0" mnemonicParsing="false" onAction="#popUpSubmit" style="-fx-background-color: E9D5B9;" text="Submit">
          <font>
             <Font name="Gulim" size="15.0" />
          </font>
       </Button>
+      <Text fx:id="error" fill="#eb0909" layoutX="85.0" layoutY="32.0" strokeType="OUTSIDE" strokeWidth="0.0" style="visibility: false;" text="Please complete all fields" textAlignment="CENTER">
+         <font>
+            <Font name="Gulim" size="18.0" />
+         </font>
+      </Text>
    </children>
    <stylesheets>
 	<URL value="@kps.css" />

--- a/KPSmart/src/views/priceupdate.fxml
+++ b/KPSmart/src/views/priceupdate.fxml
@@ -29,7 +29,7 @@
                   <Font name="Gulim" size="13.0" />
                </font>
             </Button>
-            <MenuButton fx:id="logeventmenu" layoutX="-1.0" layoutY="1.0" mnemonicParsing="false" prefHeight="24.0" prefWidth="184.0" style="-fx-background-color: E9D5B9;" text="Log Event">
+            <MenuButton fx:id="logeventmenu" layoutX="-1.0" layoutY="1.0" mnemonicParsing="false" prefHeight="24.0" prefWidth="184.0" style="-fx-background-color: E9D5B9;" text="Customer Price Update">
               <items>
                 <MenuItem fx:id="transportRoute" mnemonicParsing="false" onAction="#transportRouteAction" text="Transport Route" />
                 <MenuItem fx:id="deliveryRequest" mnemonicParsing="false" onAction="#deliveryRequestAction" text="Delivery Request" />

--- a/KPSmart/src/views/transportroute.fxml
+++ b/KPSmart/src/views/transportroute.fxml
@@ -29,7 +29,7 @@
                   <Font name="Gulim" size="13.0" />
                </font>
             </Button>
-            <MenuButton fx:id="logeventmenu" layoutX="-1.0" layoutY="1.0" mnemonicParsing="false" prefHeight="24.0" prefWidth="184.0" style="-fx-background-color: E9D5B9;" text="Log Event">
+            <MenuButton fx:id="logeventmenu" layoutX="-1.0" layoutY="1.0" mnemonicParsing="false" prefHeight="24.0" prefWidth="184.0" style="-fx-background-color: E9D5B9;" text="Transport Route">
               <items>
                 <MenuItem fx:id="transportRoute" mnemonicParsing="false" onAction="#transportRouteAction" text="Transport Route" />
                 <MenuItem fx:id="deliveryRequest" mnemonicParsing="false" onAction="#deliveryRequestAction" text="Delivery Request" />


### PR DESCRIPTION
- display expenditure and revenue to 2dp in general reports
- display itemCount with 0dp in general reports
- remove print to console in main, unless it's an actual error message
- Change title of modal box to "Enter customer price”
- Add "Please complete all fields" to the modal box when hasError is
true
- hide scrollbar on History page
- on route load page, display total items with 0dp